### PR TITLE
ci: use the correct `Makefile` target for loc

### DIFF
--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Lines of Code Counter for base
-        run: cd tooling && make loc-detailed
+        run: cd tooling && make loc
         # This creates current_detailed_loc_report.json for the base branch
 
       - name: Rename base report to previous_detailed_loc_report.json
@@ -68,7 +68,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Lines of Code Counter for PR
-        run: cd tooling && make loc-detailed
+        run: cd tooling && make loc
         # This creates current_detailed_loc_report.json
 
       - name: Compare Detailed Lines of Code Count

--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -72,7 +72,7 @@ jobs:
         # This creates current_detailed_loc_report.json
 
       - name: Compare Detailed Lines of Code Count
-        run: cd tooling && make loc-detailed-compare
+        run: cd tooling && make loc-compare
         # This reads current_detailed_loc_report.json and previous_detailed_loc_report.json
         # and outputs detailed_loc_report.txt
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,3 @@ mod rlp;
 pub mod trie;
 
 pub use db::EthrexDB;
-
-fn testing_loc() {
-    println!("testing_loc");
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,7 @@ mod rlp;
 pub mod trie;
 
 pub use db::EthrexDB;
+
+fn testing_loc() {
+    println!("testing_loc");
+}

--- a/tooling/src/report.rs
+++ b/tooling/src/report.rs
@@ -132,10 +132,10 @@ pub fn slack_detailed_message(detailed_files: &HashMap<String, usize>) -> String
     let mut files: Vec<_> = detailed_files.iter().collect();
     files.sort_by_key(|(name, _)| *name);
 
-    let mut detailed_text = format!("*Total: {} lines*\n\n", total_loc);
+    let mut detailed_text = format!("*Total: {} lines*\\n\\n", total_loc);
 
     for (file_name, loc) in files {
-        detailed_text.push_str(&format!("• `{}`: {} lines\n", file_name, loc));
+        detailed_text.push_str(&format!("`{}`: {} lines\\n", file_name, loc));
     }
 
     format!(


### PR DESCRIPTION
This PRs use `make loc` instead of `make loc-detailed`

Now it's working
<img width="1868" height="892" alt="image" src="https://github.com/user-attachments/assets/3c2c0827-5f90-4928-8846-1a3a7f3a3437" />

Commit reverted