### PR TITLE
feat: add read transaction

### DIFF
--- a/benches/db_benchmark.rs
+++ b/benches/db_benchmark.rs
@@ -177,14 +177,17 @@ fn run_ethrex_benchmark(
 
     let read_start = Instant::now();
 
+    let tx = db.begin_read().unwrap();
     for key in sample_keys {
-        db.get(key).unwrap().unwrap();
+        tx.get(key).unwrap().unwrap();
     }
 
     let read_time = read_start.elapsed();
 
     // Get root hash for validation
-    let root_hash = db.root().unwrap().compute_hash();
+    let root_hash = tx.root().unwrap().compute_hash();
+
+    drop(tx);
 
     // Cleanup
     let _ = fs::remove_file(&db_path);

--- a/benches/db_benchmark.rs
+++ b/benches/db_benchmark.rs
@@ -187,8 +187,6 @@ fn run_ethrex_benchmark(
     // Get root hash for validation
     let root_hash = tx.root().unwrap().compute_hash();
 
-    drop(tx);
-
     // Cleanup
     let _ = fs::remove_file(&db_path);
 

--- a/benches/db_benchmark.rs
+++ b/benches/db_benchmark.rs
@@ -154,7 +154,7 @@ fn run_ethrex_benchmark(
     let db_path = PathBuf::from("ethrex_bench.edb");
     let _ = fs::remove_file(&db_path);
 
-    let mut db = EthrexDB::new(db_path.clone())?;
+    let db = EthrexDB::new(db_path.clone())?;
     let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
 
     let batch_size = 15_000;

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 fn main() {
     let db_path = std::env::temp_dir().join("profile_gets.edb");
-    let mut db = EthrexDB::new(db_path).unwrap();
+    let db = EthrexDB::new(db_path).unwrap();
 
     println!("Phase 1: Inserting 1,000,000 keys...");
 

--- a/examples/profiling.rs
+++ b/examples/profiling.rs
@@ -56,7 +56,7 @@ fn main() {
             keys[rng.gen_range(0..keys.len())].clone()
         };
 
-        match db.get(key.as_bytes()).unwrap() {
+        match db.begin_read().unwrap().get(key.as_bytes()).unwrap() {
             Some(_) => hit_count += 1,
             None => miss_count += 1,
         }

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new("ethrex_transaction_example")?;
     let db_path = temp_dir.path().join("example.edb");
 
-    let mut db = EthrexDB::new(db_path)?;
+    let db = EthrexDB::new(db_path)?;
 
     println!("EthrexDB Transaction Example\n");
 

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -45,16 +45,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let protected_offsets = db.get_protected_offsets();
     assert_eq!(protected_offsets.len(), 1);
 
-    // Drop the transaction to release the immutable borrow
-    drop(read_tx);
-
-    let new_protected_offsets = db.get_protected_offsets();
-    assert_eq!(
-        new_protected_offsets.len(),
-        0,
-        "Protected offsets should be empty since we dropped the transaction"
-    );
-
     // Make changes to the database while transaction exists
     println!("\nMaking changes to database");
 

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -8,112 +8,121 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut db = EthrexDB::new(db_path)?;
 
-    println!("=== EthrexDB Transaction Example ===\n");
+    println!("EthrexDB Transaction Example\n");
 
-    // Step 1: Setup initial state
-    println!("1. Creating initial state...");
+    // Setup initial state
+    println!("Creating initial state");
     let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
     trie.insert(b"user:alice:balance".to_vec(), b"100".to_vec())?;
     trie.insert(b"user:bob:balance".to_vec(), b"50".to_vec())?;
-    trie.insert(b"contract:token:total_supply".to_vec(), b"1000000".to_vec())?;
 
     let root_node = trie.root_node()?.unwrap();
     db.commit(&root_node)?;
     trie.commit().unwrap();
 
-    println!("   ✓ Initial state committed");
-    println!("   - Alice balance: 100");
-    println!("   - Bob balance: 50");
-    println!("   - Token supply: 1000000\n");
+    println!("✓ Initial state committed");
+    println!("  - Alice balance: 100");
+    println!("  - Bob balance: 50");
 
-    // Step 2: Create a read transaction (captures current snapshot)
-    println!("2. Starting read transaction...");
+    // Create a read transaction (captures current snapshot)
+    println!("\nStarting read transaction");
     let read_tx = db.begin_read()?;
     let snapshot_offset = read_tx.snapshot_offset();
 
     println!(
-        "   ✓ Transaction created with snapshot offset: {}",
+        "✓ Transaction created with snapshot offset: {}",
         snapshot_offset
     );
-    println!("   ✓ Transaction sees:");
     println!(
-        "     - Alice: {:?}",
+        "  - Alice: {:?}",
         String::from_utf8(read_tx.get(b"user:alice:balance")?.unwrap_or_default())
     );
     println!(
-        "     - Bob: {:?}",
+        "  - Bob: {:?}",
         String::from_utf8(read_tx.get(b"user:bob:balance")?.unwrap_or_default())
     );
 
-    // Important: Drop the transaction to release the immutable borrow
+    let protected_offsets = db.get_protected_offsets();
+    assert_eq!(protected_offsets.len(), 1);
+
+    // Drop the transaction to release the immutable borrow
     drop(read_tx);
 
-    // Step 3: Make changes to the database while transaction exists
-    println!("\n3. Making changes to database (simulating concurrent updates)...");
+    let new_protected_offsets = db.get_protected_offsets();
+    assert_eq!(
+        new_protected_offsets.len(),
+        0,
+        "Protected offsets should be empty since we dropped the transaction"
+    );
+
+    // Make changes to the database while transaction exists
+    println!("\nMaking changes to database");
 
     trie.insert(b"user:alice:balance".to_vec(), b"150".to_vec())?; // Alice got +50
     trie.insert(b"user:bob:balance".to_vec(), b"25".to_vec())?; // Bob spent 25
     trie.insert(b"user:charlie:balance".to_vec(), b"75".to_vec())?; // New user Charlie
-    trie.insert(b"contract:token:total_supply".to_vec(), b"1000000".to_vec())?;
 
     let root_node2 = trie.root_node()?.unwrap();
     db.commit(&root_node2)?;
+    trie.commit().unwrap();
 
-    println!("   ✓ Changes committed to new snapshot");
-    println!("   - Alice balance: 100 → 150");
-    println!("   - Bob balance: 50 → 25");
-    println!("   - Charlie balance: 0 → 75 (new user)");
+    println!("✓ Changes committed to DB");
+    println!("  - Alice balance: 100 → 150");
+    println!("  - Bob balance: 50 → 25");
+    println!("  - Charlie balance: 0 → 75 (new user)");
 
-    // Step 4: Create transaction from old snapshot to demonstrate isolation
-    println!("\n4. Demonstrating snapshot isolation...");
-    let old_tx = ReadTransaction::new(&db, snapshot_offset);
+    // Create transaction from old snapshot to demonstrate isolation
+    println!("\nDemonstrating snapshot isolation");
+    let old_tx = ReadTransaction::new(&db, snapshot_offset, 999); // Dummy tx_id for example
     let new_tx = db.begin_read()?;
 
-    println!("   Old transaction (snapshot {}) sees:", snapshot_offset);
+    println!("✓ Old transaction (snapshot {}) sees:", snapshot_offset);
     println!(
-        "     - Alice: {:?}",
-        String::from_utf8(old_tx.get(b"user:alice:balance")?.unwrap_or_default())
+        "  - Alice: {:?}",
+        String::from_utf8(old_tx.get(b"user:alice:balance").unwrap().unwrap())
     );
     println!(
-        "     - Bob: {:?}",
-        String::from_utf8(old_tx.get(b"user:bob:balance")?.unwrap_or_default())
+        "  - Bob: {:?}",
+        String::from_utf8(old_tx.get(b"user:bob:balance").unwrap().unwrap())
     );
-    println!(
-        "     - Charlie: {:?} (None - user didn't exist)",
-        old_tx.get(b"user:charlie:balance")?
-    );
+    let charlie_balance = old_tx.get(b"user:charlie:balance").unwrap();
+    assert!(charlie_balance.is_none());
+    println!("  - Charlie: {charlie_balance:?} (None - user didn't exist)");
 
     println!(
-        "\n   New transaction (snapshot {}) sees:",
+        "\n✓ New transaction (snapshot {}) sees:",
         new_tx.snapshot_offset()
     );
     println!(
-        "     - Alice: {:?}",
-        String::from_utf8(new_tx.get(b"user:alice:balance")?.unwrap_or_default())
+        "  - Alice: {:?}",
+        String::from_utf8(new_tx.get(b"user:alice:balance").unwrap().unwrap())
     );
     println!(
-        "     - Bob: {:?}",
-        String::from_utf8(new_tx.get(b"user:bob:balance")?.unwrap_or_default())
-    );
-    println!(
-        "     - Charlie: {:?}",
-        String::from_utf8(new_tx.get(b"user:charlie:balance")?.unwrap_or_default())
+        "  - Bob: {:?}",
+        String::from_utf8(new_tx.get(b"user:bob:balance").unwrap().unwrap())
     );
 
-    // Step 5: Latest transaction always sees most recent data
-    println!("\n5. Latest transaction (always sees most recent data):");
+    let charlie_balance = new_tx.get(b"user:charlie:balance").unwrap();
+    assert!(charlie_balance.is_some());
+    println!(
+        "  - Charlie: {:?}",
+        String::from_utf8(charlie_balance.unwrap())
+    );
+
+    // Latest transaction always sees most recent data
+    println!("\nLatest transaction (always sees most recent data):");
     let latest_tx = db.begin_read()?;
     println!(
-        "     - Alice: {:?}",
-        String::from_utf8(latest_tx.get(b"user:alice:balance")?.unwrap_or_default())
+        "  - Alice: {:?}",
+        String::from_utf8(latest_tx.get(b"user:alice:balance").unwrap().unwrap())
     );
     println!(
-        "     - Bob: {:?}",
-        String::from_utf8(latest_tx.get(b"user:bob:balance")?.unwrap_or_default())
+        "   - Bob: {:?}",
+        String::from_utf8(latest_tx.get(b"user:bob:balance").unwrap().unwrap())
     );
     println!(
-        "     - Charlie: {:?}",
-        String::from_utf8(latest_tx.get(b"user:charlie:balance")?.unwrap_or_default())
+        "   - Charlie: {:?}",
+        String::from_utf8(latest_tx.get(b"user:charlie:balance").unwrap().unwrap())
     );
 
     Ok(())

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -1,0 +1,120 @@
+use ethrexdb::trie::{InMemoryTrieDB, Trie};
+use ethrexdb::{EthrexDB, ReadTransaction};
+use tempdir::TempDir;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new("ethrex_transaction_example")?;
+    let db_path = temp_dir.path().join("example.edb");
+
+    let mut db = EthrexDB::new(db_path)?;
+
+    println!("=== EthrexDB Transaction Example ===\n");
+
+    // Step 1: Setup initial state
+    println!("1. Creating initial state...");
+    let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+    trie.insert(b"user:alice:balance".to_vec(), b"100".to_vec())?;
+    trie.insert(b"user:bob:balance".to_vec(), b"50".to_vec())?;
+    trie.insert(b"contract:token:total_supply".to_vec(), b"1000000".to_vec())?;
+
+    let root_node = trie.root_node()?.unwrap();
+    db.commit(&root_node)?;
+    trie.commit().unwrap();
+
+    println!("   ✓ Initial state committed");
+    println!("   - Alice balance: 100");
+    println!("   - Bob balance: 50");
+    println!("   - Token supply: 1000000\n");
+
+    // Step 2: Create a read transaction (captures current snapshot)
+    println!("2. Starting read transaction...");
+    let read_tx = db.begin_read()?;
+    let snapshot_offset = read_tx.snapshot_offset();
+
+    println!(
+        "   ✓ Transaction created with snapshot offset: {}",
+        snapshot_offset
+    );
+    println!("   ✓ Transaction sees:");
+    println!(
+        "     - Alice: {:?}",
+        String::from_utf8(read_tx.get(b"user:alice:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Bob: {:?}",
+        String::from_utf8(read_tx.get(b"user:bob:balance")?.unwrap_or_default())
+    );
+
+    // Important: Drop the transaction to release the immutable borrow
+    drop(read_tx);
+
+    // Step 3: Make changes to the database while transaction exists
+    println!("\n3. Making changes to database (simulating concurrent updates)...");
+
+    trie.insert(b"user:alice:balance".to_vec(), b"150".to_vec())?; // Alice got +50
+    trie.insert(b"user:bob:balance".to_vec(), b"25".to_vec())?; // Bob spent 25
+    trie.insert(b"user:charlie:balance".to_vec(), b"75".to_vec())?; // New user Charlie
+    trie.insert(b"contract:token:total_supply".to_vec(), b"1000000".to_vec())?;
+
+    let root_node2 = trie.root_node()?.unwrap();
+    db.commit(&root_node2)?;
+
+    println!("   ✓ Changes committed to new snapshot");
+    println!("   - Alice balance: 100 → 150");
+    println!("   - Bob balance: 50 → 25");
+    println!("   - Charlie balance: 0 → 75 (new user)");
+
+    // Step 4: Create transaction from old snapshot to demonstrate isolation
+    println!("\n4. Demonstrating snapshot isolation...");
+    let old_tx = ReadTransaction::new(&db, snapshot_offset);
+    let new_tx = db.begin_read()?;
+
+    println!("   Old transaction (snapshot {}) sees:", snapshot_offset);
+    println!(
+        "     - Alice: {:?}",
+        String::from_utf8(old_tx.get(b"user:alice:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Bob: {:?}",
+        String::from_utf8(old_tx.get(b"user:bob:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Charlie: {:?} (None - user didn't exist)",
+        old_tx.get(b"user:charlie:balance")?
+    );
+
+    println!(
+        "\n   New transaction (snapshot {}) sees:",
+        new_tx.snapshot_offset()
+    );
+    println!(
+        "     - Alice: {:?}",
+        String::from_utf8(new_tx.get(b"user:alice:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Bob: {:?}",
+        String::from_utf8(new_tx.get(b"user:bob:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Charlie: {:?}",
+        String::from_utf8(new_tx.get(b"user:charlie:balance")?.unwrap_or_default())
+    );
+
+    // Step 5: Latest transaction always sees most recent data
+    println!("\n5. Latest transaction (always sees most recent data):");
+    let latest_tx = db.begin_read()?;
+    println!(
+        "     - Alice: {:?}",
+        String::from_utf8(latest_tx.get(b"user:alice:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Bob: {:?}",
+        String::from_utf8(latest_tx.get(b"user:bob:balance")?.unwrap_or_default())
+    );
+    println!(
+        "     - Charlie: {:?}",
+        String::from_utf8(latest_tx.get(b"user:charlie:balance")?.unwrap_or_default())
+    );
+
+    Ok(())
+}

--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -1,5 +1,5 @@
+use ethrexdb::EthrexDB;
 use ethrexdb::trie::{InMemoryTrieDB, Trie};
-use ethrexdb::{EthrexDB, ReadTransaction};
 use tempdir::TempDir;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,111 +8,253 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let db = EthrexDB::new(db_path)?;
 
-    println!("EthrexDB Transaction Example\n");
+    println!("EthrexDB Multi-Reader Single-Writer Transaction Demo\n");
+
+    // Initially no active transactions
+    assert_eq!(
+        db.active_transaction_count(),
+        0,
+        "Should start with no active transactions"
+    );
+    println!(
+        "Initial state: {} active transactions",
+        db.active_transaction_count()
+    );
 
     // Setup initial state
-    println!("Creating initial state");
+    println!("\n--- Setting up initial blockchain state ---");
     let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-    trie.insert(b"user:alice:balance".to_vec(), b"100".to_vec())?;
-    trie.insert(b"user:bob:balance".to_vec(), b"50".to_vec())?;
+    trie.insert(b"account:0x1:balance".to_vec(), b"1000".to_vec())?;
+    trie.insert(b"account:0x2:balance".to_vec(), b"500".to_vec())?;
+    trie.insert(b"account:0x3:balance".to_vec(), b"250".to_vec())?;
 
     let root_node = trie.root_node()?.unwrap();
     db.commit(&root_node)?;
     trie.commit().unwrap();
 
-    println!("✓ Initial state committed");
-    println!("  - Alice balance: 100");
-    println!("  - Bob balance: 50");
+    println!("Block 1 committed");
+    println!("  - Account 0x1: 1000 ETH");
+    println!("  - Account 0x2: 500 ETH");
+    println!("  - Account 0x3: 250 ETH");
 
-    // Create a read transaction (captures current snapshot)
-    println!("\nStarting read transaction");
-    let read_tx = db.begin_read()?;
-    let snapshot_offset = read_tx.snapshot_offset();
+    // Multiple Concurrent Readers
+    println!("\n--- Creating multiple concurrent read transactions ---");
+
+    let tx1 = db.begin_read()?;
+    let tx2 = db.begin_read()?;
+    let tx3 = db.begin_read()?;
+
+    assert_eq!(
+        db.active_transaction_count(),
+        3,
+        "Should have 3 active transactions"
+    );
+    println!("Created 3 concurrent read transactions");
+    println!("  - Active transactions: {}", db.active_transaction_count());
+    println!(
+        "  - Protected snapshots: {}",
+        db.get_protected_offsets().len()
+    );
+
+    // All transactions should see the same data (same snapshot)
+    let snapshot_offset = tx1.snapshot_offset();
+    assert_eq!(
+        tx1.snapshot_offset(),
+        tx2.snapshot_offset(),
+        "Same snapshot offset"
+    );
+    assert_eq!(
+        tx2.snapshot_offset(),
+        tx3.snapshot_offset(),
+        "Same snapshot offset"
+    );
 
     println!(
-        "✓ Transaction created with snapshot offset: {}",
+        "  - All transactions share snapshot offset: {}",
         snapshot_offset
     );
-    println!(
-        "  - Alice: {:?}",
-        String::from_utf8(read_tx.get(b"user:alice:balance")?.unwrap_or_default())
-    );
-    println!(
-        "  - Bob: {:?}",
-        String::from_utf8(read_tx.get(b"user:bob:balance")?.unwrap_or_default())
-    );
 
-    let protected_offsets = db.get_protected_offsets();
-    assert_eq!(protected_offsets.len(), 1);
+    // Validate all readers can read concurrently
+    let balance_0x1_tx1 = tx1.get(b"account:0x1:balance")?.unwrap();
+    let balance_0x1_tx2 = tx2.get(b"account:0x1:balance")?.unwrap();
+    let balance_0x1_tx3 = tx3.get(b"account:0x1:balance")?.unwrap();
 
-    // Make changes to the database while transaction exists
-    println!("\nMaking changes to database");
+    assert_eq!(balance_0x1_tx1, b"1000", "TX1 should see correct balance");
+    assert_eq!(balance_0x1_tx2, b"1000", "TX2 should see correct balance");
+    assert_eq!(balance_0x1_tx3, b"1000", "TX3 should see correct balance");
 
-    trie.insert(b"user:alice:balance".to_vec(), b"150".to_vec())?; // Alice got +50
-    trie.insert(b"user:bob:balance".to_vec(), b"25".to_vec())?; // Bob spent 25
-    trie.insert(b"user:charlie:balance".to_vec(), b"75".to_vec())?; // New user Charlie
+    // Writer commits while readers are active, this should demonstrate snapshot isolation
+    println!("\n--- Committing new block while readers are active ---");
+
+    // Simulate a block with transactions
+    trie.insert(b"account:0x1:balance".to_vec(), b"800".to_vec())?; // 0x1 sent 200
+    trie.insert(b"account:0x2:balance".to_vec(), b"700".to_vec())?; // 0x2 received 200
+    trie.insert(b"account:0x4:balance".to_vec(), b"100".to_vec())?; // New account 0x4
 
     let root_node2 = trie.root_node()?.unwrap();
     db.commit(&root_node2)?;
     trie.commit().unwrap();
 
-    println!("✓ Changes committed to DB");
-    println!("  - Alice balance: 100 → 150");
-    println!("  - Bob balance: 50 → 25");
-    println!("  - Charlie balance: 0 → 75 (new user)");
+    println!("Block 2 committed while 3 readers still active");
+    println!("  - Account 0x1: 1000 → 800 ETH (sent 200)");
+    println!("  - Account 0x2: 500 → 700 ETH (received 200)");
+    println!("  - Account 0x4: 0 → 100 ETH (new account)");
 
-    // Create transaction from old snapshot to demonstrate isolation
-    println!("\nDemonstrating snapshot isolation");
-    let old_tx = ReadTransaction::new(&db, snapshot_offset, 999); // Dummy tx_id for example
-    let new_tx = db.begin_read()?;
+    println!("\n--- SNAPSHOT ISOLATION VERIFICATION ---");
 
-    println!("✓ Old transaction (snapshot {}) sees:", snapshot_offset);
-    println!(
-        "  - Alice: {:?}",
-        String::from_utf8(old_tx.get(b"user:alice:balance").unwrap().unwrap())
-    );
-    println!(
-        "  - Bob: {:?}",
-        String::from_utf8(old_tx.get(b"user:bob:balance").unwrap().unwrap())
-    );
-    let charlie_balance = old_tx.get(b"user:charlie:balance").unwrap();
-    assert!(charlie_balance.is_none());
-    println!("  - Charlie: {charlie_balance:?} (None - user didn't exist)");
+    // Old readers should still see old data (snapshot isolation)
+    let old_balance_0x1_tx1 = String::from_utf8(tx1.get(b"account:0x1:balance")?.unwrap()).unwrap();
+    let old_balance_0x1_tx2 = String::from_utf8(tx2.get(b"account:0x1:balance")?.unwrap()).unwrap();
+    let old_balance_0x1_tx3 = String::from_utf8(tx3.get(b"account:0x1:balance")?.unwrap()).unwrap();
+    let new_account_tx3 = tx3.get(b"account:0x4:balance")?;
 
+    println!("Old readers (TX1-3) still see Block 1 data:");
     println!(
-        "\n✓ New transaction (snapshot {}) sees:",
-        new_tx.snapshot_offset()
+        "  - TX1 sees account 0x1 balance: {} ETH",
+        old_balance_0x1_tx1
     );
     println!(
-        "  - Alice: {:?}",
-        String::from_utf8(new_tx.get(b"user:alice:balance").unwrap().unwrap())
+        "  - TX2 sees account 0x1 balance: {} ETH",
+        old_balance_0x1_tx2
     );
     println!(
-        "  - Bob: {:?}",
-        String::from_utf8(new_tx.get(b"user:bob:balance").unwrap().unwrap())
+        "  - TX3 sees account 0x1 balance: {} ETH",
+        old_balance_0x1_tx3
+    );
+    println!(
+        "  - TX3 sees account 0x4 balance: {:?} (new account not visible)",
+        new_account_tx3
     );
 
-    let charlie_balance = new_tx.get(b"user:charlie:balance").unwrap();
-    assert!(charlie_balance.is_some());
-    println!(
-        "  - Charlie: {:?}",
-        String::from_utf8(charlie_balance.unwrap())
+    assert_eq!(
+        old_balance_0x1_tx1, "1000",
+        "TX1 should still see old balance"
+    );
+    assert_eq!(
+        old_balance_0x1_tx2, "1000",
+        "TX2 should still see old balance"
+    );
+    assert_eq!(
+        old_balance_0x1_tx3, "1000",
+        "TX3 should still see old balance"
+    );
+    assert!(new_account_tx3.is_none(), "TX3 should not see new account");
+
+    // New reader should see new data
+    let tx4 = db.begin_read()?;
+    assert_eq!(
+        db.active_transaction_count(),
+        4,
+        "Should now have 4 active transactions"
     );
 
-    // Latest transaction always sees most recent data
-    println!("\nLatest transaction (always sees most recent data):");
-    let latest_tx = db.begin_read()?;
+    let new_balance_0x1 = String::from_utf8(tx4.get(b"account:0x1:balance")?.unwrap()).unwrap();
+    let new_balance_0x2 = String::from_utf8(tx4.get(b"account:0x2:balance")?.unwrap()).unwrap();
+    let new_balance_0x3 = String::from_utf8(tx4.get(b"account:0x3:balance")?.unwrap()).unwrap();
+    let new_account_0x4 = String::from_utf8(tx4.get(b"account:0x4:balance")?.unwrap()).unwrap();
+
+    println!("\nNew reader (TX4) sees Block 2 data:");
+    println!("  - TX4 sees account 0x1 balance: {} ETH", new_balance_0x1);
+    println!("  - TX4 sees account 0x2 balance: {} ETH", new_balance_0x2);
+    println!("  - TX4 sees account 0x3 balance: {} ETH", new_balance_0x3);
+    println!("  - TX4 sees account 0x4 balance: {} ETH", new_account_0x4);
+
+    assert_eq!(new_balance_0x1, "800", "TX4 should see new balance");
+    assert_eq!(new_balance_0x2, "700", "TX4 should see new balance");
+    assert_eq!(new_account_0x4, "100", "TX4 should see new account");
+
+    // Transaction lifecycle
+    println!("\n--- Transaction reference counting and cleanup ---");
+
+    let protected_offsets_before = db.get_protected_offsets();
     println!(
-        "  - Alice: {:?}",
-        String::from_utf8(latest_tx.get(b"user:alice:balance").unwrap().unwrap())
+        "Protected offsets before cleanup: {:?}",
+        protected_offsets_before
+    );
+    assert_eq!(
+        protected_offsets_before.len(),
+        2,
+        "Should protect 2 different snapshots"
+    );
+
+    // Drop old transactions
+    drop(tx1);
+    drop(tx2);
+    drop(tx3);
+
+    assert_eq!(
+        db.active_transaction_count(),
+        1,
+        "Should have 1 active transaction after drops"
+    );
+
+    let protected_offsets_after = db.get_protected_offsets();
+    println!(
+        "After dropping TX1-3, active transactions: {}",
+        db.active_transaction_count()
     );
     println!(
-        "   - Bob: {:?}",
-        String::from_utf8(latest_tx.get(b"user:bob:balance").unwrap().unwrap())
+        "Protected offsets after cleanup: {:?}",
+        protected_offsets_after
+    );
+    assert_eq!(
+        protected_offsets_after.len(),
+        1,
+        "Should only protect 1 snapshot now"
+    );
+
+    // Multiple snapshots from different blocks
+    println!("\n--- Multiple readers from different block snapshots ---");
+
+    // Create another block
+    trie.insert(b"account:0x1:balance".to_vec(), b"600".to_vec())?; // 0x1 sent 200 more
+    trie.insert(b"account:0x3:balance".to_vec(), b"450".to_vec())?; // 0x3 received 200
+
+    let root_node3 = trie.root_node()?.unwrap();
+    db.commit(&root_node3)?;
+    trie.commit().unwrap();
+
+    println!("Block 3 committed");
+    println!("  - Account 0x1: 800 → 600 ETH (sent 200 more)");
+    println!("  - Account 0x3: 250 → 450 ETH (received 200)\n");
+
+    // Create readers from different snapshots
+    let tx_block2 = tx4; // Keep reference to block 2 reader
+    let tx_block3 = db.begin_read()?; // New reader sees block 3
+
+    assert_ne!(
+        tx_block2.snapshot_offset(),
+        tx_block3.snapshot_offset(),
+        "Different transactions should have different snapshot offsets"
+    );
+
+    // Verify each sees their respective block data
+    let block2_balance =
+        String::from_utf8(tx_block2.get(b"account:0x1:balance")?.unwrap()).unwrap();
+    let block3_balance =
+        String::from_utf8(tx_block3.get(b"account:0x1:balance")?.unwrap()).unwrap();
+
+    assert_eq!(block2_balance, "800", "Block 2 reader sees block 2 state");
+    assert_eq!(block3_balance, "600", "Block 3 reader sees block 3 state");
+
+    println!(
+        "TX from block 2 snapshot sees: 0x1 = {} ETH",
+        block2_balance
     );
     println!(
-        "   - Charlie: {:?}",
-        String::from_utf8(latest_tx.get(b"user:charlie:balance").unwrap().unwrap())
+        "TX from block 3 snapshot sees: 0x1 = {} ETH",
+        block3_balance
+    );
+
+    assert_eq!(
+        db.active_transaction_count(),
+        2,
+        "Should end with 2 active transactions"
+    );
+    assert_eq!(
+        db.get_protected_offsets().len(),
+        2,
+        "Should protect 2 snapshots"
     );
 
     Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-//! EthrexDB - Merkle Patricia Trie Database
+//! EthrexDB - Merkle Patricia Trie Database with MVCC Transaction Support
 //!
 //! The database implements Copy-on-Write (CoW) optimization where only modified nodes
 //! are written during commits. Unchanged nodes are referenced by their file offset,
@@ -8,14 +8,24 @@
 //! Each commit creates a new root that links to the previous root via a prepended
 //! offset, forming a linked list of all historical states. This allows traversing
 //! the entire version history if needed.
+//!
+//! ## Transaction System
+//!
+//! All data access must be performed through read transactions, which provide
+//! snapshot isolation guarantees:
+//!
 
 use crate::file_manager::FileManager;
 use crate::index::Index;
 use crate::serialization::{Deserializer, Serializer};
+use crate::transaction::ReadTransaction;
 use crate::trie::{Node, NodeHash, TrieError};
 use std::path::PathBuf;
 
-/// Ethrex DB struct
+/// Ethrex DB struct - A transactional Merkle Patricia Trie database
+///
+/// This database requires all read operations to be performed through transactions
+/// to ensure snapshot isolation and data consistency.
 pub struct EthrexDB {
     /// File manager
     file_manager: FileManager,
@@ -69,33 +79,42 @@ impl EthrexDB {
         Ok(root_hash)
     }
 
-    /// Get the latest root node of the database
-    pub fn root(&self) -> Result<Node, TrieError> {
-        let latest_offset = self.file_manager.read_latest_root_offset()?;
-        if latest_offset == 0 {
-            panic!("No root node in database");
+    /// Get the root node at a specific offset
+    pub(crate) fn root_at_offset(&self, root_offset: u64) -> Result<Node, TrieError> {
+        if root_offset == 0 {
+            panic!("No root node at offset");
         }
 
         let file_data = self.file_manager.get_slice_to_end(0)?;
-        // All roots now have 8-byte prepended previous root offset
-        let actual_root_offset = latest_offset + 8;
+        // All roots have 8-byte prepended previous root offset
+        let actual_root_offset = root_offset + 8;
 
         Deserializer::new(file_data).decode_node_at(actual_root_offset as usize)
     }
 
-    /// Get the value of the node with the given key
-    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, TrieError> {
-        let latest_offset = self.file_manager.read_latest_root_offset()?;
-        if latest_offset == 0 {
+    /// Get the value of a key at a specific root offset
+    pub(crate) fn get_at_offset(
+        &self,
+        key: &[u8],
+        root_offset: u64,
+    ) -> Result<Option<Vec<u8>>, TrieError> {
+        if root_offset == 0 {
             return Ok(None);
         }
 
         let file_data = self.file_manager.get_slice_to_end(0)?;
-
         // All roots have 8-byte prepended previous root offset
-        let actual_root_offset = latest_offset + 8;
+        let actual_root_offset = root_offset + 8;
 
         Deserializer::new(file_data).get_by_path_at(key, actual_root_offset as usize)
+    }
+
+    /// Begin a new read transaction that captures the current state of the database
+    /// The transaction will provide a consistent snapshot view and will not see
+    /// any changes committed after the transaction is created
+    pub fn begin_read(&self) -> Result<ReadTransaction, TrieError> {
+        let snapshot_root_offset = self.file_manager.read_latest_root_offset()?;
+        Ok(ReadTransaction::new(self, snapshot_root_offset))
     }
 }
 
@@ -137,7 +156,8 @@ mod tests {
         }
 
         let db = EthrexDB::open(db_path).unwrap();
-        let value = db.get(b"key").unwrap();
+        let tx = db.begin_read().unwrap();
+        let value = tx.get(b"key").unwrap();
         assert_eq!(value, Some(b"value".to_vec()));
     }
 
@@ -149,7 +169,9 @@ mod tests {
         let mut db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Test getting from empty db
-        assert_eq!(db.get(b"nonexistent").unwrap(), None);
+        let tx = db.begin_read().unwrap();
+        assert_eq!(tx.get(b"nonexistent").unwrap(), None);
+        drop(tx);
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"hello".to_vec(), b"world".to_vec()).unwrap();
@@ -160,12 +182,13 @@ mod tests {
         db.commit(&root_node).unwrap();
 
         // Test getting existing values
-        assert_eq!(db.get(b"hello").unwrap(), Some(b"world".to_vec()));
-        assert_eq!(db.get(b"foo").unwrap(), Some(b"bar".to_vec()));
-        assert_eq!(db.get(b"test").unwrap(), Some(b"value".to_vec()));
+        let tx = db.begin_read().unwrap();
+        assert_eq!(tx.get(b"hello").unwrap(), Some(b"world".to_vec()));
+        assert_eq!(tx.get(b"foo").unwrap(), Some(b"bar".to_vec()));
+        assert_eq!(tx.get(b"test").unwrap(), Some(b"value".to_vec()));
 
         // Test getting non-existent value
-        assert_eq!(db.get(b"nonexistent").unwrap(), None);
+        assert_eq!(tx.get(b"nonexistent").unwrap(), None);
     }
 
     #[test]
@@ -182,7 +205,9 @@ mod tests {
         db.commit(&root_node).unwrap();
         trie.commit().unwrap();
 
-        assert_eq!(db.root().unwrap(), root_node);
+        let tx = db.begin_read().unwrap();
+        assert_eq!(tx.root().unwrap(), root_node);
+        drop(tx);
 
         // let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"key2".to_vec(), b"value2".to_vec()).unwrap();
@@ -191,7 +216,9 @@ mod tests {
         db.commit(&root_node).unwrap();
         trie.commit().unwrap();
 
-        assert_eq!(db.root().unwrap(), root_node);
+        let tx = db.begin_read().unwrap();
+        assert_eq!(tx.root().unwrap(), root_node);
+        drop(tx);
 
         trie.insert(b"key3".to_vec(), b"value3".to_vec()).unwrap();
         trie.insert(b"common".to_vec(), b"v3".to_vec()).unwrap();
@@ -199,14 +226,15 @@ mod tests {
         db.commit(&root_node).unwrap();
         trie.commit().unwrap();
 
-        assert_eq!(db.root().unwrap(), root_node);
+        let tx = db.begin_read().unwrap();
+        assert_eq!(tx.root().unwrap(), root_node);
 
-        assert_eq!(db.get(b"key3").unwrap(), Some(b"value3".to_vec()));
-        assert_eq!(db.get(b"common").unwrap(), Some(b"v3".to_vec()));
-        assert_eq!(db.get(b"key1").unwrap(), Some(b"value1".to_vec()));
-        assert_eq!(db.get(b"key2").unwrap(), Some(b"value2".to_vec()));
+        assert_eq!(tx.get(b"key3").unwrap(), Some(b"value3".to_vec()));
+        assert_eq!(tx.get(b"common").unwrap(), Some(b"v3".to_vec()));
+        assert_eq!(tx.get(b"key1").unwrap(), Some(b"value1".to_vec()));
+        assert_eq!(tx.get(b"key2").unwrap(), Some(b"value2".to_vec()));
 
-        assert_eq!(db.get(b"nonexistent").unwrap(), None);
+        assert_eq!(tx.get(b"nonexistent").unwrap(), None);
     }
 
     #[test]
@@ -249,12 +277,14 @@ mod tests {
         let root_node = trie_v2.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
 
+        let tx = db.begin_read().unwrap();
         for (key, expected_value) in &test_data_v2 {
-            let result = db.get(key).unwrap();
+            let result = tx.get(key).unwrap();
             assert_eq!(result, Some(expected_value.clone()));
         }
 
-        assert_eq!(db.get(b"nonexistent").unwrap(), None);
+        assert_eq!(tx.get(b"nonexistent").unwrap(), None);
+        drop(tx);
 
         let complex_test_data = vec![
             (
@@ -275,8 +305,9 @@ mod tests {
         let root_node = trie_v3.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
 
+        let tx = db.begin_read().unwrap();
         for (key, expected_value) in &complex_test_data {
-            let result = db.get(key).unwrap();
+            let result = tx.get(key).unwrap();
             assert_eq!(result, Some(expected_value.clone()));
         }
     }
@@ -338,11 +369,13 @@ mod tests {
             trie_root_hash1, db_root_hash1,
             "Root hashes must match after batch 1"
         );
+        let tx = db.begin_read().unwrap();
         assert_eq!(
-            db.root().unwrap(),
+            tx.root().unwrap(),
             root_node1,
             "DB root must match trie root after batch 1"
         );
+        drop(tx);
 
         // Batch 2: New transactions + modify some existing accounts
         let new_accounts_batch2 = generate_test_data(150);
@@ -370,11 +403,13 @@ mod tests {
             trie_root_hash2, db_root_hash2,
             "Root hashes must match after batch 2"
         );
+        let tx = db.begin_read().unwrap();
         assert_eq!(
-            db.root().unwrap(),
+            tx.root().unwrap(),
             root_node2,
             "DB root must match trie root after batch 2"
         );
+        drop(tx);
 
         // Batch 3: More transactions
         let new_accounts_batch3 = generate_test_data(200);
@@ -403,11 +438,13 @@ mod tests {
             trie_root_hash3, db_root_hash3,
             "Root hashes must match after batch 3"
         );
+        let tx = db.begin_read().unwrap();
         assert_eq!(
-            db.root().unwrap(),
+            tx.root().unwrap(),
             root_node3,
             "DB root must match trie root after batch 3"
         );
+        drop(tx);
 
         // Batch 4: Large update batch
         let new_accounts_batch4 = generate_test_data(250);
@@ -436,11 +473,13 @@ mod tests {
             trie_root_hash4, db_root_hash4,
             "Root hashes must match after batch 4"
         );
+        let tx = db.begin_read().unwrap();
         assert_eq!(
-            db.root().unwrap(),
+            tx.root().unwrap(),
             root_node4,
             "DB root must match trie root after batch 4"
         );
+        drop(tx);
 
         // Batch 5: Final verification batch
         let new_accounts_batch5 = generate_test_data(300);
@@ -469,17 +508,20 @@ mod tests {
             trie_root_hash5, db_root_hash5,
             "Root hashes must match after batch 5"
         );
+        let tx = db.begin_read().unwrap();
         assert_eq!(
-            db.root().unwrap(),
+            tx.root().unwrap(),
             root_node5,
             "DB root must match trie root after batch 5"
         );
+        drop(tx);
 
         // Random verification of some accounts
+        let tx = db.begin_read().unwrap();
         for batch_num in 1..=5 {
             let test_data = generate_test_data(batch_num * 50);
             if let Some((key, _)) = test_data.get(batch_num * 10) {
-                assert_eq!(db.get(key).unwrap(), trie.get(key).unwrap());
+                assert_eq!(tx.get(key).unwrap(), trie.get(key).unwrap());
             }
         }
     }
@@ -517,5 +559,83 @@ mod tests {
         // File after update should have a very small increase
         assert!(insert_file_size < update_file_size);
         assert!(update_file_size < insert_file_size + 1000);
+    }
+
+    #[test]
+    fn test_transaction_integration() {
+        let temp_dir = TempDir::new("ethrex_db_tx_integration").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Create initial state
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"account1".to_vec(), b"balance1".to_vec())
+            .unwrap();
+        trie.insert(b"account2".to_vec(), b"balance2".to_vec())
+            .unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+
+        // Test snapshot isolation with scoped transaction
+        {
+            let read_tx = db.begin_read().unwrap();
+
+            // Verify initial state
+            assert_eq!(
+                read_tx.get(b"account1").unwrap(),
+                Some(b"balance1".to_vec())
+            );
+            assert_eq!(
+                read_tx.get(b"account2").unwrap(),
+                Some(b"balance2".to_vec())
+            );
+            assert_eq!(read_tx.get(b"account3").unwrap(), None);
+
+            // Store snapshot for later
+            let snapshot_offset = read_tx.snapshot_offset();
+
+            // End scope to release borrow
+            drop(read_tx);
+
+            // Make changes after transaction was created
+            let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+            trie2
+                .insert(b"account1".to_vec(), b"updated_balance1".to_vec())
+                .unwrap();
+            trie2
+                .insert(b"account2".to_vec(), b"updated_balance2".to_vec())
+                .unwrap();
+            trie2
+                .insert(b"account3".to_vec(), b"new_balance3".to_vec())
+                .unwrap();
+            let root_node2 = trie2.root_node().unwrap().unwrap();
+            db.commit(&root_node2).unwrap();
+
+            // Create new transaction using the old snapshot
+            let old_read_tx = crate::transaction::ReadTransaction::new(&db, snapshot_offset);
+
+            // Verify transaction still sees old data
+            assert_eq!(
+                old_read_tx.get(b"account1").unwrap(),
+                Some(b"balance1".to_vec())
+            );
+            assert_eq!(
+                old_read_tx.get(b"account2").unwrap(),
+                Some(b"balance2".to_vec())
+            );
+            assert_eq!(old_read_tx.get(b"account3").unwrap(), None);
+
+            // But new transaction sees new data
+            let new_read_tx = db.begin_read().unwrap();
+            assert_eq!(
+                new_read_tx.get(b"account1").unwrap(),
+                Some(b"updated_balance1".to_vec())
+            );
+            assert_eq!(
+                new_read_tx.get(b"account3").unwrap(),
+                Some(b"new_balance3".to_vec())
+            );
+        }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,7 @@ use crate::transaction::ReadTransaction;
 use crate::transaction_manager::TransactionManager;
 use crate::trie::{Node, NodeHash, TrieError};
 use std::path::PathBuf;
-// TODO: Should we use Mutex or other sync?
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, RwLock};
 
 /// Ethrex DB struct - A transactional Merkle Patricia Trie database
@@ -36,6 +36,10 @@ pub struct EthrexDB {
     /// Index mapping node hashes to their file offsets
     /// TODO: Read from file if it exists to
     node_index: RwLock<Index>,
+    /// Latest root offset stored atomically
+    latest_root_offset: AtomicU64,
+    /// Mutex to ensure only one commit at a time
+    commit_mutex: Mutex<()>,
     /// Transaction manager for reference counting and safe pruning
     transaction_manager: Mutex<TransactionManager>,
 }
@@ -45,10 +49,15 @@ impl EthrexDB {
     pub fn new(file_path: PathBuf) -> Result<Self, TrieError> {
         let file_manager = FileManager::create(file_path.clone())?;
         let node_index = Index::new();
+        // Empty DB has root offset 0
+        let latest_root_offset = AtomicU64::new(0);
+        let commit_mutex = Mutex::new(());
         let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
             file_manager: RwLock::new(file_manager),
             node_index: RwLock::new(node_index),
+            latest_root_offset,
+            commit_mutex,
             transaction_manager,
         })
     }
@@ -58,42 +67,56 @@ impl EthrexDB {
         let file_manager = FileManager::open(file_path.clone())?;
         // TODO: Read node index from file if it exists
         let node_index = Index::new();
+        let latest_root_offset = AtomicU64::new(file_manager.read_latest_root_offset()?);
+        let commit_mutex = Mutex::new(());
         let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
             file_manager: RwLock::new(file_manager),
             node_index: RwLock::new(node_index),
+            latest_root_offset,
+            commit_mutex,
             transaction_manager,
         })
     }
 
     /// Commit a trie state to the database
     pub fn commit(&self, root_node: &Node) -> Result<NodeHash, TrieError> {
-        let root_hash = root_node.compute_hash();
+        // Ensure only one commit at a time
+        let _commit_guard = self.commit_mutex.lock().map_err(|_| TrieError::LockError)?;
 
-        // Get write locks for both file_manager and node_index
-        let mut file_manager = self
-            .file_manager
-            .write()
-            .map_err(|_| TrieError::LockError)?;
-        let mut node_index = self.node_index.write().map_err(|_| TrieError::LockError)?;
+        let prev_root_offset = self.latest_root_offset.load(Ordering::Acquire);
 
-        let prev_root_offset = file_manager.read_latest_root_offset()?;
-        let base_offset = file_manager.get_file_size()?;
+        let base_offset = {
+            let fm = self.file_manager.read().map_err(|_| TrieError::LockError)?;
+            fm.get_file_size()?
+        }; // Drop read lock
 
-        let serializer = Serializer::new(&node_index, base_offset);
-        let (serialized_data, new_offsets, root_offset) =
-            serializer.serialize_tree(root_node, prev_root_offset)?;
+        let (serialized_data, new_offsets, root_offset) = {
+            let node_index = self.node_index.read().map_err(|_| TrieError::LockError)?;
+            let serializer = Serializer::new(&node_index, base_offset);
+            serializer.serialize_tree(root_node, prev_root_offset)?
+        }; // Drop node_index read lock here
 
-        file_manager.write_at_end(&serialized_data)?;
+        {
+            let mut fm = self
+                .file_manager
+                .write()
+                .map_err(|_| TrieError::LockError)?;
+            fm.write_at_end(&serialized_data)?;
+            fm.update_latest_root_offset(root_offset)?;
+        } // Drop write lock
 
-        // Update node index with new node offsets
-        for (hash, absolute_offset) in new_offsets {
-            node_index.insert(hash, absolute_offset);
-        }
+        {
+            let mut node_index = self.node_index.write().map_err(|_| TrieError::LockError)?;
+            for (hash, absolute_offset) in new_offsets {
+                node_index.insert(hash, absolute_offset);
+            }
+        } // Drop write lock
 
-        // Update header to point to the root node
-        file_manager.update_latest_root_offset(root_offset)?;
-        Ok(root_hash)
+        self.latest_root_offset
+            .store(root_offset, Ordering::Release);
+
+        Ok(root_node.compute_hash())
     }
 
     /// Get the root node at a specific offset
@@ -132,12 +155,7 @@ impl EthrexDB {
     /// The transaction will provide a consistent snapshot view and will not see
     /// any changes committed after the transaction is created
     pub fn begin_read(&self) -> Result<ReadTransaction, TrieError> {
-        let snapshot_root_offset = {
-            self.file_manager
-                .read()
-                .map_err(|_| TrieError::LockError)?
-                .read_latest_root_offset()?
-        };
+        let snapshot_root_offset = self.latest_root_offset.load(Ordering::Acquire);
 
         // Register the snapshot with the transaction manager
         let tx_id = self
@@ -186,7 +204,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"hello".to_vec(), b"world".to_vec()).unwrap();
@@ -203,7 +221,7 @@ mod tests {
         let db_path = temp_dir.path().join("test.edb");
 
         {
-            let mut db = EthrexDB::new(db_path.clone()).unwrap();
+            let db = EthrexDB::new(db_path.clone()).unwrap();
 
             let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
             trie.insert(b"key".to_vec(), b"value".to_vec()).unwrap();
@@ -222,7 +240,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Test getting from empty db
         let tx = db.begin_read().unwrap();
@@ -252,7 +270,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
@@ -316,7 +334,7 @@ mod tests {
             (b"0xabcdef".to_vec(), b"hex_new".to_vec()),
         ];
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         for (key, value) in &test_data_v1 {
@@ -406,7 +424,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_blockchain_sim").unwrap();
         let db_path = temp_dir.path().join("blockchain.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
 
         // Batch 1: Initial accounts
@@ -587,7 +605,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
 
@@ -623,7 +641,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_tx_integration").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Create initial state
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
@@ -699,7 +717,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_txmgr_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Initially no active transactions
         assert_eq!(db.active_transaction_count(), 0);

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,6 +22,7 @@ use crate::transaction::ReadTransaction;
 use crate::transaction_manager::TransactionManager;
 use crate::trie::{Node, NodeHash, TrieError};
 use std::path::PathBuf;
+// TODO: Should we use Mutex or other sync?
 use std::sync::Mutex;
 
 /// Ethrex DB struct - A transactional Merkle Patricia Trie database
@@ -250,7 +251,6 @@ mod tests {
         assert_eq!(tx.root().unwrap(), root_node);
         drop(tx);
 
-        // let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"key2".to_vec(), b"value2".to_vec()).unwrap();
         trie.insert(b"common".to_vec(), b"v2".to_vec()).unwrap();
         let root_node = trie.root_node().unwrap().unwrap();
@@ -304,19 +304,20 @@ mod tests {
 
         let mut db = EthrexDB::new(db_path.clone()).unwrap();
 
-        let mut trie_v1 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         for (key, value) in &test_data_v1 {
-            trie_v1.insert(key.clone(), value.clone()).unwrap();
+            trie.insert(key.clone(), value.clone()).unwrap();
         }
-        let root_node = trie_v1.root_node().unwrap().unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
 
-        let mut trie_v2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         for (key, value) in &test_data_v2 {
-            trie_v2.insert(key.clone(), value.clone()).unwrap();
+            trie.insert(key.clone(), value.clone()).unwrap();
         }
-        let root_node = trie_v2.root_node().unwrap().unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
 
         let tx = db.begin_read().unwrap();
         for (key, expected_value) in &test_data_v2 {
@@ -336,15 +337,15 @@ mod tests {
             (b"".to_vec(), b"empty_key_value".to_vec()),
         ];
 
-        let mut trie_v3 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         for (key, value) in &test_data_v2 {
-            trie_v3.insert(key.clone(), value.clone()).unwrap();
+            trie.insert(key.clone(), value.clone()).unwrap();
         }
         for (key, value) in &complex_test_data {
-            trie_v3.insert(key.clone(), value.clone()).unwrap();
+            trie.insert(key.clone(), value.clone()).unwrap();
         }
-        let root_node = trie_v3.root_node().unwrap().unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
 
         let tx = db.begin_read().unwrap();
         for (key, expected_value) in &complex_test_data {
@@ -594,6 +595,7 @@ mod tests {
             .unwrap();
         let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
         // Check file size after updating a single key
         let update_file_size = std::fs::metadata(db_path).unwrap().len();
 
@@ -617,6 +619,7 @@ mod tests {
             .unwrap();
         let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
 
         // Test snapshot isolation with scoped transaction
         {
@@ -640,18 +643,15 @@ mod tests {
             drop(read_tx);
 
             // Make changes after transaction was created
-            let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-            trie2
-                .insert(b"account1".to_vec(), b"updated_balance1".to_vec())
+            trie.insert(b"account1".to_vec(), b"updated_balance1".to_vec())
                 .unwrap();
-            trie2
-                .insert(b"account2".to_vec(), b"updated_balance2".to_vec())
+            trie.insert(b"account2".to_vec(), b"updated_balance2".to_vec())
                 .unwrap();
-            trie2
-                .insert(b"account3".to_vec(), b"new_balance3".to_vec())
+            trie.insert(b"account3".to_vec(), b"new_balance3".to_vec())
                 .unwrap();
-            let root_node2 = trie2.root_node().unwrap().unwrap();
+            let root_node2 = trie.root_node().unwrap().unwrap();
             db.commit(&root_node2).unwrap();
+            trie.commit().unwrap();
 
             // Create new transaction using the old snapshot
             let old_read_tx = crate::transaction::ReadTransaction::new(&db, snapshot_offset, 999); // Dummy tx_id for test
@@ -695,12 +695,13 @@ mod tests {
         trie.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
         let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
+        trie.commit().unwrap();
 
         // Create a transaction - should register snapshot
         let tx1 = db.begin_read().unwrap();
         assert_eq!(db.active_transaction_count(), 1);
 
-        let _tx1_offset = tx1.snapshot_offset();
+        let tx1_offset = tx1.snapshot_offset();
 
         // Create another transaction at the same snapshot
         let tx2 = db.begin_read().unwrap();
@@ -711,10 +712,10 @@ mod tests {
         drop(tx2);
 
         // Commit new data and create another transaction
-        let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-        trie2.insert(b"key1".to_vec(), b"value2".to_vec()).unwrap();
-        let root_node2 = trie2.root_node().unwrap().unwrap();
+        trie.insert(b"key1".to_vec(), b"value2".to_vec()).unwrap();
+        let root_node2 = trie.root_node().unwrap().unwrap();
         db.commit(&root_node2).unwrap();
+        trie.commit().unwrap();
 
         // Check that no transactions are active after dropping
         assert_eq!(db.active_transaction_count(), 0);
@@ -723,7 +724,7 @@ mod tests {
         assert_eq!(db.active_transaction_count(), 1);
 
         let tx3_offset = tx3.snapshot_offset();
-        assert_ne!(_tx1_offset, tx3_offset);
+        assert_ne!(tx1_offset, tx3_offset);
 
         // Drop transaction
         drop(tx3);
@@ -756,6 +757,7 @@ mod tests {
         trie.insert(b"test2".to_vec(), b"data2".to_vec()).unwrap();
         let root_node2 = trie.root_node().unwrap().unwrap();
         db.commit(&root_node2).unwrap();
+        trie.commit().unwrap();
 
         // Create new transaction to test current state
         let tx3 = db.begin_read().unwrap(); // Latest snapshot
@@ -766,38 +768,5 @@ mod tests {
         // Verify transaction works
         assert_eq!(tx3.get(b"test").unwrap(), Some(b"data".to_vec()));
         assert_eq!(tx3.get(b"test2").unwrap(), Some(b"data2".to_vec()));
-    }
-
-    #[test]
-    fn test_transaction_ids_unique() {
-        let temp_dir = TempDir::new("ethrex_db_txid_test").unwrap();
-        let db_path = temp_dir.path().join("test.edb");
-
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
-
-        // Create initial state
-        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-        trie.insert(b"test".to_vec(), b"data".to_vec()).unwrap();
-        let root_node = trie.root_node().unwrap().unwrap();
-        db.commit(&root_node).unwrap();
-
-        // Create multiple transactions and verify unique IDs
-        let tx1 = db.begin_read().unwrap();
-        let tx2 = db.begin_read().unwrap();
-        let tx3 = db.begin_read().unwrap();
-
-        let id1 = tx1.transaction_id();
-        let id2 = tx2.transaction_id();
-        let id3 = tx3.transaction_id();
-
-        // All IDs should be different
-        assert_ne!(id1, id2);
-        assert_ne!(id2, id3);
-        assert_ne!(id1, id3);
-
-        // All IDs should be > 0
-        assert!(id1 > 0);
-        assert!(id2 > 0);
-        assert!(id3 > 0);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,19 +19,24 @@ use crate::file_manager::FileManager;
 use crate::index::Index;
 use crate::serialization::{Deserializer, Serializer};
 use crate::transaction::ReadTransaction;
+use crate::transaction_manager::TransactionManager;
 use crate::trie::{Node, NodeHash, TrieError};
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 /// Ethrex DB struct - A transactional Merkle Patricia Trie database
 ///
 /// This database requires all read operations to be performed through transactions
-/// to ensure snapshot isolation and data consistency.
+/// to ensure snapshot isolation and data consistency. It includes reference counting
+/// to prevent pruning of snapshots that are still in use.
 pub struct EthrexDB {
     /// File manager
     file_manager: FileManager,
     /// Index mapping node hashes to their file offsets
     /// TODO: Read from file if it exists to
     node_index: Index,
+    /// Transaction manager for reference counting and safe pruning
+    transaction_manager: Mutex<TransactionManager>,
 }
 
 impl EthrexDB {
@@ -39,9 +44,11 @@ impl EthrexDB {
     pub fn new(file_path: PathBuf) -> Result<Self, TrieError> {
         let file_manager = FileManager::create(file_path.clone())?;
         let node_index = Index::new();
+        let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
             file_manager,
             node_index,
+            transaction_manager,
         })
     }
 
@@ -50,9 +57,11 @@ impl EthrexDB {
         let file_manager = FileManager::open(file_path.clone())?;
         // TODO: Read node index from file if it exists
         let node_index = Index::new();
+        let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
             file_manager,
             node_index,
+            transaction_manager,
         })
     }
 
@@ -114,7 +123,39 @@ impl EthrexDB {
     /// any changes committed after the transaction is created
     pub fn begin_read(&self) -> Result<ReadTransaction, TrieError> {
         let snapshot_root_offset = self.file_manager.read_latest_root_offset()?;
-        Ok(ReadTransaction::new(self, snapshot_root_offset))
+
+        // Register the snapshot with the transaction manager
+        let tx_id = self
+            .transaction_manager
+            .lock()
+            .map_err(|_| TrieError::LockError)?
+            .register_snapshot(snapshot_root_offset);
+
+        Ok(ReadTransaction::new(self, snapshot_root_offset, tx_id))
+    }
+
+    /// Unregisters a snapshot from the transaction manager
+    /// This is called internally when a transaction is dropped
+    pub(crate) fn unregister_snapshot(&self, offset: u64) {
+        if let Ok(mut tm) = self.transaction_manager.lock() {
+            tm.unregister_snapshot(offset);
+        }
+    }
+
+    /// Returns the total number of active transactions
+    pub fn active_transaction_count(&self) -> usize {
+        self.transaction_manager
+            .lock()
+            .map(|tm| tm.active_transaction_count())
+            .unwrap_or(0)
+    }
+
+    /// Returns a list of all active snapshot offsets that should not be pruned
+    pub fn get_protected_offsets(&self) -> Vec<u64> {
+        self.transaction_manager
+            .lock()
+            .map(|tm| tm.get_active_offsets())
+            .unwrap_or_default()
     }
 }
 
@@ -613,7 +654,7 @@ mod tests {
             db.commit(&root_node2).unwrap();
 
             // Create new transaction using the old snapshot
-            let old_read_tx = crate::transaction::ReadTransaction::new(&db, snapshot_offset);
+            let old_read_tx = crate::transaction::ReadTransaction::new(&db, snapshot_offset, 999); // Dummy tx_id for test
 
             // Verify transaction still sees old data
             assert_eq!(
@@ -637,5 +678,126 @@ mod tests {
                 Some(b"new_balance3".to_vec())
             );
         }
+    }
+
+    #[test]
+    fn test_transaction_manager_reference_counting() {
+        let temp_dir = TempDir::new("ethrex_db_txmgr_test").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Initially no active transactions
+        assert_eq!(db.active_transaction_count(), 0);
+
+        // Create initial state
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+
+        // Create a transaction - should register snapshot
+        let tx1 = db.begin_read().unwrap();
+        assert_eq!(db.active_transaction_count(), 1);
+
+        let _tx1_offset = tx1.snapshot_offset();
+
+        // Create another transaction at the same snapshot
+        let tx2 = db.begin_read().unwrap();
+        assert_eq!(db.active_transaction_count(), 2);
+
+        // Drop transactions to allow commit
+        drop(tx1);
+        drop(tx2);
+
+        // Commit new data and create another transaction
+        let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie2.insert(b"key1".to_vec(), b"value2".to_vec()).unwrap();
+        let root_node2 = trie2.root_node().unwrap().unwrap();
+        db.commit(&root_node2).unwrap();
+
+        // Check that no transactions are active after dropping
+        assert_eq!(db.active_transaction_count(), 0);
+
+        let tx3 = db.begin_read().unwrap();
+        assert_eq!(db.active_transaction_count(), 1);
+
+        let tx3_offset = tx3.snapshot_offset();
+        assert_ne!(_tx1_offset, tx3_offset);
+
+        // Drop transaction
+        drop(tx3);
+        assert_eq!(db.active_transaction_count(), 0);
+    }
+
+    #[test]
+    fn test_transaction_manager_info() {
+        let temp_dir = TempDir::new("ethrex_db_txmgr_info_test").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Create initial state
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"test".to_vec(), b"data".to_vec()).unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+
+        // Create multiple transactions
+        let tx1 = db.begin_read().unwrap();
+        let _tx2 = db.begin_read().unwrap(); // Same snapshot
+        let _tx1_offset = tx1.snapshot_offset();
+
+        // Drop transactions to allow commit
+        drop(tx1);
+        drop(_tx2);
+
+        // Commit new data
+        trie.insert(b"test2".to_vec(), b"data2".to_vec()).unwrap();
+        let root_node2 = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node2).unwrap();
+
+        // Create new transaction to test current state
+        let tx3 = db.begin_read().unwrap(); // Latest snapshot
+
+        let protected_offsets = db.get_protected_offsets();
+        assert_eq!(protected_offsets.len(), 1);
+
+        // Verify transaction works
+        assert_eq!(tx3.get(b"test").unwrap(), Some(b"data".to_vec()));
+        assert_eq!(tx3.get(b"test2").unwrap(), Some(b"data2".to_vec()));
+    }
+
+    #[test]
+    fn test_transaction_ids_unique() {
+        let temp_dir = TempDir::new("ethrex_db_txid_test").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Create initial state
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"test".to_vec(), b"data".to_vec()).unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+
+        // Create multiple transactions and verify unique IDs
+        let tx1 = db.begin_read().unwrap();
+        let tx2 = db.begin_read().unwrap();
+        let tx3 = db.begin_read().unwrap();
+
+        let id1 = tx1.transaction_id();
+        let id2 = tx2.transaction_id();
+        let id3 = tx3.transaction_id();
+
+        // All IDs should be different
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+
+        // All IDs should be > 0
+        assert!(id1 > 0);
+        assert!(id2 > 0);
+        assert!(id3 > 0);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,7 +23,7 @@ use crate::transaction_manager::TransactionManager;
 use crate::trie::{Node, NodeHash, TrieError};
 use std::path::PathBuf;
 // TODO: Should we use Mutex or other sync?
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 /// Ethrex DB struct - A transactional Merkle Patricia Trie database
 ///
@@ -32,10 +32,10 @@ use std::sync::Mutex;
 /// to prevent pruning of snapshots that are still in use.
 pub struct EthrexDB {
     /// File manager
-    file_manager: FileManager,
+    file_manager: RwLock<FileManager>,
     /// Index mapping node hashes to their file offsets
     /// TODO: Read from file if it exists to
-    node_index: Index,
+    node_index: RwLock<Index>,
     /// Transaction manager for reference counting and safe pruning
     transaction_manager: Mutex<TransactionManager>,
 }
@@ -47,8 +47,8 @@ impl EthrexDB {
         let node_index = Index::new();
         let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
-            file_manager,
-            node_index,
+            file_manager: RwLock::new(file_manager),
+            node_index: RwLock::new(node_index),
             transaction_manager,
         })
     }
@@ -60,32 +60,39 @@ impl EthrexDB {
         let node_index = Index::new();
         let transaction_manager = Mutex::new(TransactionManager::new());
         Ok(Self {
-            file_manager,
-            node_index,
+            file_manager: RwLock::new(file_manager),
+            node_index: RwLock::new(node_index),
             transaction_manager,
         })
     }
 
     /// Commit a trie state to the database
-    pub fn commit(&mut self, root_node: &Node) -> Result<NodeHash, TrieError> {
+    pub fn commit(&self, root_node: &Node) -> Result<NodeHash, TrieError> {
         let root_hash = root_node.compute_hash();
 
-        let prev_root_offset = self.file_manager.read_latest_root_offset()?;
-        let base_offset = self.file_manager.get_file_size()?;
+        // Get write locks for both file_manager and node_index
+        let mut file_manager = self
+            .file_manager
+            .write()
+            .map_err(|_| TrieError::LockError)?;
+        let mut node_index = self.node_index.write().map_err(|_| TrieError::LockError)?;
 
-        let serializer = Serializer::new(&self.node_index, base_offset);
+        let prev_root_offset = file_manager.read_latest_root_offset()?;
+        let base_offset = file_manager.get_file_size()?;
+
+        let serializer = Serializer::new(&node_index, base_offset);
         let (serialized_data, new_offsets, root_offset) =
             serializer.serialize_tree(root_node, prev_root_offset)?;
 
-        self.file_manager.write_at_end(&serialized_data)?;
+        file_manager.write_at_end(&serialized_data)?;
 
         // Update node index with new node offsets
         for (hash, absolute_offset) in new_offsets {
-            self.node_index.insert(hash, absolute_offset);
+            node_index.insert(hash, absolute_offset);
         }
 
         // Update header to point to the root node
-        self.file_manager.update_latest_root_offset(root_offset)?;
+        file_manager.update_latest_root_offset(root_offset)?;
         Ok(root_hash)
     }
 
@@ -95,7 +102,8 @@ impl EthrexDB {
             panic!("No root node at offset");
         }
 
-        let file_data = self.file_manager.get_slice_to_end(0)?;
+        let file_manager = self.file_manager.read().map_err(|_| TrieError::LockError)?;
+        let file_data = file_manager.get_slice_to_end(0)?;
         // All roots have 8-byte prepended previous root offset
         let actual_root_offset = root_offset + 8;
 
@@ -112,7 +120,8 @@ impl EthrexDB {
             return Ok(None);
         }
 
-        let file_data = self.file_manager.get_slice_to_end(0)?;
+        let file_manager = self.file_manager.read().map_err(|_| TrieError::LockError)?;
+        let file_data = file_manager.get_slice_to_end(0)?;
         // All roots have 8-byte prepended previous root offset
         let actual_root_offset = root_offset + 8;
 
@@ -123,7 +132,12 @@ impl EthrexDB {
     /// The transaction will provide a consistent snapshot view and will not see
     /// any changes committed after the transaction is created
     pub fn begin_read(&self) -> Result<ReadTransaction, TrieError> {
-        let snapshot_root_offset = self.file_manager.read_latest_root_offset()?;
+        let snapshot_root_offset = {
+            self.file_manager
+                .read()
+                .map_err(|_| TrieError::LockError)?
+                .read_latest_root_offset()?
+        };
 
         // Register the snapshot with the transaction manager
         let tx_id = self
@@ -736,7 +750,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_txmgr_info_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Create initial state
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
@@ -746,12 +760,7 @@ mod tests {
 
         // Create multiple transactions
         let tx1 = db.begin_read().unwrap();
-        let _tx2 = db.begin_read().unwrap(); // Same snapshot
-        let _tx1_offset = tx1.snapshot_offset();
-
-        // Drop transactions to allow commit
-        drop(tx1);
-        drop(_tx2);
+        let tx2 = db.begin_read().unwrap(); // Same snapshot
 
         // Commit new data
         trie.insert(b"test2".to_vec(), b"data2".to_vec()).unwrap();
@@ -759,11 +768,18 @@ mod tests {
         db.commit(&root_node2).unwrap();
         trie.commit().unwrap();
 
+        assert_eq!(tx1.get(b"test").unwrap(), Some(b"data".to_vec()));
+        assert_eq!(tx1.get(b"test2").unwrap(), None);
+        assert_eq!(tx2.get(b"test").unwrap(), Some(b"data".to_vec()));
+        assert_eq!(tx2.get(b"test2").unwrap(), None);
+
         // Create new transaction to test current state
         let tx3 = db.begin_read().unwrap(); // Latest snapshot
 
         let protected_offsets = db.get_protected_offsets();
-        assert_eq!(protected_offsets.len(), 1);
+        // tx1 and tx2 are protected in the same snapshot
+        // tx3 is protected in the new snapshot
+        assert_eq!(protected_offsets.len(), 2);
 
         // Verify transaction works
         assert_eq!(tx3.get(b"test").unwrap(), Some(b"data".to_vec()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod index;
 mod serialization;
 /// Transaction management for snapshot isolation.
 mod transaction;
+/// Transaction manager for reference counting and safe pruning.
+mod transaction_manager;
 
 // ETHREX COPY STRUCTURES
 mod rlp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,12 @@ mod file_manager;
 pub mod index;
 /// Serialization and deserialization of the trie.
 mod serialization;
+/// Transaction management for snapshot isolation.
+mod transaction;
 
 // ETHREX COPY STRUCTURES
 mod rlp;
 pub mod trie;
 
 pub use db::EthrexDB;
+pub use transaction::ReadTransaction;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,21 +1,26 @@
 use crate::db::EthrexDB;
+use crate::transaction_manager::TransactionId;
 use crate::trie::{Node, TrieError};
 
 /// A read-only transaction that provides a consistent snapshot view of the database
-/// at the time the transaction was created.
+/// at the time the transaction was created. The transaction is automatically
+/// unregistered from the transaction manager when dropped.
 pub struct ReadTransaction<'a> {
     /// The root offset captured when the transaction was created
     snapshot_root_offset: u64,
     /// Reference to the database
     db: &'a EthrexDB,
+    /// Unique transaction identifier
+    tx_id: TransactionId,
 }
 
 impl<'a> ReadTransaction<'a> {
-    /// Creates a new read transaction with the specified snapshot offset
-    pub fn new(db: &'a EthrexDB, snapshot_root_offset: u64) -> Self {
+    /// Creates a new read transaction with the specified snapshot offset and transaction ID
+    pub fn new(db: &'a EthrexDB, snapshot_root_offset: u64, tx_id: TransactionId) -> Self {
         Self {
             snapshot_root_offset,
             db,
+            tx_id,
         }
     }
 
@@ -35,12 +40,17 @@ impl<'a> ReadTransaction<'a> {
     pub fn snapshot_offset(&self) -> u64 {
         self.snapshot_root_offset
     }
+
+    /// Get the transaction ID
+    pub fn transaction_id(&self) -> TransactionId {
+        self.tx_id
+    }
 }
 
 impl<'a> Drop for ReadTransaction<'a> {
     fn drop(&mut self) {
-        // For now, this is a no-op. In the future, we could implement
-        // reference counting to prevent pruning of snapshots in use.
+        // Automatically unregister the snapshot from the transaction manager
+        self.db.unregister_snapshot(self.snapshot_root_offset);
     }
 }
 
@@ -67,7 +77,7 @@ mod tests {
         // Create read transaction - captures current snapshot
         {
             let read_tx = db.begin_read().unwrap();
-            
+
             // Verify transaction can read the initial state
             assert_eq!(read_tx.get(b"key1").unwrap(), Some(b"value1".to_vec()));
             assert_eq!(read_tx.get(b"key2").unwrap(), Some(b"value2".to_vec()));
@@ -80,24 +90,33 @@ mod tests {
             drop(read_tx);
 
             // Make changes to the database after transaction creation
-            let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-            trie2.insert(b"key1".to_vec(), b"modified_value1".to_vec()).unwrap();
-            trie2.insert(b"key2".to_vec(), b"modified_value2".to_vec()).unwrap();
-            trie2.insert(b"key3".to_vec(), b"new_value3".to_vec()).unwrap();
-            let root_node2 = trie2.root_node().unwrap().unwrap();
+            trie.insert(b"key1".to_vec(), b"modified_value1".to_vec())
+                .unwrap();
+            trie.insert(b"key2".to_vec(), b"modified_value2".to_vec())
+                .unwrap();
+            trie.insert(b"key3".to_vec(), b"new_value3".to_vec())
+                .unwrap();
+            let root_node2 = trie.root_node().unwrap().unwrap();
             db.commit(&root_node2).unwrap();
 
             // Create a new transaction with the old snapshot to verify isolation
-            let old_tx = ReadTransaction::new(&db, snapshot_offset);
-            
+            let old_tx = ReadTransaction::new(&db, snapshot_offset, 999); // Dummy tx_id for test
+
             // Transaction should NOT see the new changes - snapshot isolation
             assert_eq!(old_tx.get(b"key1").unwrap(), Some(b"value1".to_vec())); // Still old value
             assert_eq!(old_tx.get(b"key2").unwrap(), Some(b"value2".to_vec())); // Still old value
             assert_eq!(old_tx.get(b"key3").unwrap(), None); // New key not visible
-            
-            // But new transaction sees the new values  
+
+            // But new transaction sees the new values
             let new_tx = db.begin_read().unwrap();
-            assert_eq!(new_tx.get(b"key1").unwrap(), Some(b"modified_value1".to_vec()));
+            assert_eq!(
+                new_tx.get(b"key1").unwrap(),
+                Some(b"modified_value1".to_vec())
+            );
+            assert_eq!(
+                new_tx.get(b"key2").unwrap(),
+                Some(b"modified_value2".to_vec())
+            );
             assert_eq!(new_tx.get(b"key3").unwrap(), Some(b"new_value3".to_vec()));
         }
     }
@@ -109,40 +128,37 @@ mod tests {
 
         let mut db = EthrexDB::new(db_path.clone()).unwrap();
 
-        // Version 1
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"counter".to_vec(), b"1".to_vec()).unwrap();
         let root_node = trie.root_node().unwrap().unwrap();
         db.commit(&root_node).unwrap();
-        
+        trie.commit().unwrap();
+
         let offset1 = db.begin_read().unwrap().snapshot_offset();
 
-        // Version 2
-        let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-        trie2.insert(b"counter".to_vec(), b"2".to_vec()).unwrap();
-        let root_node2 = trie2.root_node().unwrap().unwrap();
+        trie.insert(b"counter".to_vec(), b"2".to_vec()).unwrap();
+        let root_node2 = trie.root_node().unwrap().unwrap();
         db.commit(&root_node2).unwrap();
+        trie.commit().unwrap();
 
         let offset2 = db.begin_read().unwrap().snapshot_offset();
 
-        // Version 3
-        let mut trie3 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
-        trie3.insert(b"counter".to_vec(), b"3".to_vec()).unwrap();
-        let root_node3 = trie3.root_node().unwrap().unwrap();
+        trie.insert(b"counter".to_vec(), b"3".to_vec()).unwrap();
+        let root_node3 = trie.root_node().unwrap().unwrap();
         db.commit(&root_node3).unwrap();
 
         // Create transactions for each snapshot
-        let tx1 = ReadTransaction::new(&db, offset1);
-        let tx2 = ReadTransaction::new(&db, offset2);
+        let tx1 = ReadTransaction::new(&db, offset1, 998); // Dummy tx_id for test
+        let tx2 = ReadTransaction::new(&db, offset2, 999); // Dummy tx_id for test
 
         // Each transaction should see its own snapshot
         assert_eq!(tx1.get(b"counter").unwrap(), Some(b"1".to_vec()));
         assert_eq!(tx2.get(b"counter").unwrap(), Some(b"2".to_vec()));
-        
+
         // Latest transaction sees current state
         let latest_tx = db.begin_read().unwrap();
         assert_eq!(latest_tx.get(b"counter").unwrap(), Some(b"3".to_vec()));
-        
+
         // Verify snapshot offsets are different
         assert!(tx1.snapshot_offset() < tx2.snapshot_offset());
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,149 @@
+use crate::db::EthrexDB;
+use crate::trie::{Node, TrieError};
+
+/// A read-only transaction that provides a consistent snapshot view of the database
+/// at the time the transaction was created.
+pub struct ReadTransaction<'a> {
+    /// The root offset captured when the transaction was created
+    snapshot_root_offset: u64,
+    /// Reference to the database
+    db: &'a EthrexDB,
+}
+
+impl<'a> ReadTransaction<'a> {
+    /// Creates a new read transaction with the specified snapshot offset
+    pub fn new(db: &'a EthrexDB, snapshot_root_offset: u64) -> Self {
+        Self {
+            snapshot_root_offset,
+            db,
+        }
+    }
+
+    /// Get the value for a key from this transaction's snapshot
+    /// This will always return the value as it existed when the transaction was created,
+    /// regardless of any commits that happen after the transaction started
+    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, TrieError> {
+        self.db.get_at_offset(key, self.snapshot_root_offset)
+    }
+
+    /// Get the root node from this transaction's snapshot
+    pub fn root(&self) -> Result<Node, TrieError> {
+        self.db.root_at_offset(self.snapshot_root_offset)
+    }
+
+    /// Get the snapshot offset this transaction is reading from
+    pub fn snapshot_offset(&self) -> u64 {
+        self.snapshot_root_offset
+    }
+}
+
+impl<'a> Drop for ReadTransaction<'a> {
+    fn drop(&mut self) {
+        // For now, this is a no-op. In the future, we could implement
+        // reference counting to prevent pruning of snapshots in use.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trie::{InMemoryTrieDB, Trie};
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_read_transaction_snapshot_isolation() {
+        let temp_dir = TempDir::new("ethrex_db_tx_test").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Setup initial state
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
+        trie.insert(b"key2".to_vec(), b"value2".to_vec()).unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+
+        // Create read transaction - captures current snapshot
+        {
+            let read_tx = db.begin_read().unwrap();
+            
+            // Verify transaction can read the initial state
+            assert_eq!(read_tx.get(b"key1").unwrap(), Some(b"value1".to_vec()));
+            assert_eq!(read_tx.get(b"key2").unwrap(), Some(b"value2".to_vec()));
+            assert_eq!(read_tx.get(b"nonexistent").unwrap(), None);
+
+            // Store the snapshot offset to verify later
+            let snapshot_offset = read_tx.snapshot_offset();
+
+            // Drop the transaction to release the immutable borrow
+            drop(read_tx);
+
+            // Make changes to the database after transaction creation
+            let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+            trie2.insert(b"key1".to_vec(), b"modified_value1".to_vec()).unwrap();
+            trie2.insert(b"key2".to_vec(), b"modified_value2".to_vec()).unwrap();
+            trie2.insert(b"key3".to_vec(), b"new_value3".to_vec()).unwrap();
+            let root_node2 = trie2.root_node().unwrap().unwrap();
+            db.commit(&root_node2).unwrap();
+
+            // Create a new transaction with the old snapshot to verify isolation
+            let old_tx = ReadTransaction::new(&db, snapshot_offset);
+            
+            // Transaction should NOT see the new changes - snapshot isolation
+            assert_eq!(old_tx.get(b"key1").unwrap(), Some(b"value1".to_vec())); // Still old value
+            assert_eq!(old_tx.get(b"key2").unwrap(), Some(b"value2".to_vec())); // Still old value
+            assert_eq!(old_tx.get(b"key3").unwrap(), None); // New key not visible
+            
+            // But new transaction sees the new values  
+            let new_tx = db.begin_read().unwrap();
+            assert_eq!(new_tx.get(b"key1").unwrap(), Some(b"modified_value1".to_vec()));
+            assert_eq!(new_tx.get(b"key3").unwrap(), Some(b"new_value3".to_vec()));
+        }
+    }
+
+    #[test]
+    fn test_multiple_read_transactions() {
+        let temp_dir = TempDir::new("ethrex_db_multi_tx_test").unwrap();
+        let db_path = temp_dir.path().join("test.edb");
+
+        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+
+        // Version 1
+        let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie.insert(b"counter".to_vec(), b"1".to_vec()).unwrap();
+        let root_node = trie.root_node().unwrap().unwrap();
+        db.commit(&root_node).unwrap();
+        
+        let offset1 = db.begin_read().unwrap().snapshot_offset();
+
+        // Version 2
+        let mut trie2 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie2.insert(b"counter".to_vec(), b"2".to_vec()).unwrap();
+        let root_node2 = trie2.root_node().unwrap().unwrap();
+        db.commit(&root_node2).unwrap();
+
+        let offset2 = db.begin_read().unwrap().snapshot_offset();
+
+        // Version 3
+        let mut trie3 = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
+        trie3.insert(b"counter".to_vec(), b"3".to_vec()).unwrap();
+        let root_node3 = trie3.root_node().unwrap().unwrap();
+        db.commit(&root_node3).unwrap();
+
+        // Create transactions for each snapshot
+        let tx1 = ReadTransaction::new(&db, offset1);
+        let tx2 = ReadTransaction::new(&db, offset2);
+
+        // Each transaction should see its own snapshot
+        assert_eq!(tx1.get(b"counter").unwrap(), Some(b"1".to_vec()));
+        assert_eq!(tx2.get(b"counter").unwrap(), Some(b"2".to_vec()));
+        
+        // Latest transaction sees current state
+        let latest_tx = db.begin_read().unwrap();
+        assert_eq!(latest_tx.get(b"counter").unwrap(), Some(b"3".to_vec()));
+        
+        // Verify snapshot offsets are different
+        assert!(tx1.snapshot_offset() < tx2.snapshot_offset());
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -65,7 +65,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_tx_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         // Setup initial state
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
@@ -126,7 +126,7 @@ mod tests {
         let temp_dir = TempDir::new("ethrex_db_multi_tx_test").unwrap();
         let db_path = temp_dir.path().join("test.edb");
 
-        let mut db = EthrexDB::new(db_path.clone()).unwrap();
+        let db = EthrexDB::new(db_path.clone()).unwrap();
 
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::new_empty()));
         trie.insert(b"counter".to_vec(), b"1".to_vec()).unwrap();

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -25,13 +25,13 @@ impl TransactionManager {
     /// Registers a new transaction using the given snapshot offset
     /// Returns a unique transaction ID
     pub fn register_snapshot(&mut self, offset: u64) -> TransactionId {
-        let tx_id = self.next_tx_id.fetch_add(1, Ordering::SeqCst);
+        let tx_id = self.next_tx_id.fetch_add(1, Ordering::Relaxed);
 
         // Increment reference count for this offset
         self.active_snapshots
             .entry(offset)
             .or_insert_with(|| AtomicU64::new(0))
-            .fetch_add(1, Ordering::SeqCst);
+            .fetch_add(1, Ordering::Relaxed);
 
         tx_id
     }
@@ -40,7 +40,7 @@ impl TransactionManager {
     /// If the count reaches zero, the snapshot is removed from tracking
     pub fn unregister_snapshot(&mut self, offset: u64) {
         if let Some(count) = self.active_snapshots.get(&offset) {
-            let new_count = count.fetch_sub(1, Ordering::SeqCst);
+            let new_count = count.fetch_sub(1, Ordering::Relaxed);
 
             // If count reached 0 (was 1, now 0), remove from HashMap
             if new_count == 1 {
@@ -58,7 +58,7 @@ impl TransactionManager {
     pub fn active_transaction_count(&self) -> usize {
         self.active_snapshots
             .values()
-            .map(|count| count.load(Ordering::SeqCst) as usize)
+            .map(|count| count.load(Ordering::Relaxed) as usize)
             .sum()
     }
 }

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Unique identifier for transactions
+pub type TransactionId = u64;
+
+/// This manager tracks which root offsets are currently being used by active
+/// read transactions
+pub struct TransactionManager {
+    /// Maps root offsets to the number of active transactions using them
+    active_snapshots: HashMap<u64, AtomicU64>,
+    /// Counter for generating unique transaction IDs
+    next_tx_id: AtomicU64,
+}
+
+impl TransactionManager {
+    /// Creates a new transaction manager
+    pub fn new() -> Self {
+        Self {
+            active_snapshots: HashMap::new(),
+            next_tx_id: AtomicU64::new(1),
+        }
+    }
+
+    /// Registers a new transaction using the given snapshot offset
+    /// Returns a unique transaction ID
+    pub fn register_snapshot(&mut self, offset: u64) -> TransactionId {
+        let tx_id = self.next_tx_id.fetch_add(1, Ordering::SeqCst);
+
+        // Increment reference count for this offset
+        self.active_snapshots
+            .entry(offset)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::SeqCst);
+
+        tx_id
+    }
+
+    /// Unregisters a transaction, decrementing the reference count
+    /// If the count reaches zero, the snapshot is removed from tracking
+    pub fn unregister_snapshot(&mut self, offset: u64) {
+        if let Some(count) = self.active_snapshots.get(&offset) {
+            let new_count = count.fetch_sub(1, Ordering::SeqCst);
+
+            // If count reached 0 (was 1, now 0), remove from HashMap
+            if new_count == 1 {
+                self.active_snapshots.remove(&offset);
+            }
+        }
+    }
+
+    /// Returns all currently active snapshot offsets
+    pub fn get_active_offsets(&self) -> Vec<u64> {
+        self.active_snapshots.keys().copied().collect()
+    }
+
+    /// Returns the total number of active transactions
+    pub fn active_transaction_count(&self) -> usize {
+        self.active_snapshots
+            .values()
+            .map(|count| count.load(Ordering::SeqCst) as usize)
+            .sum()
+    }
+}
+
+impl Default for TransactionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_and_unregister_single_transaction() {
+        let mut tm = TransactionManager::new();
+
+        // No active transactions initially
+        assert_eq!(tm.active_transaction_count(), 0);
+
+        // Register a transaction
+        let tx_id = tm.register_snapshot(1000);
+        assert!(tx_id > 0);
+        assert_eq!(tm.active_transaction_count(), 1);
+
+        let active_offsets = tm.get_active_offsets();
+        assert_eq!(active_offsets.len(), 1);
+        assert!(active_offsets.contains(&1000));
+
+        // Unregister the transaction
+        tm.unregister_snapshot(1000);
+        assert_eq!(tm.active_transaction_count(), 0);
+        assert_eq!(tm.get_active_offsets().len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_transactions_same_snapshot() {
+        let mut tm = TransactionManager::new();
+
+        // Register two transactions for the same offset
+        let tx1 = tm.register_snapshot(1000);
+        let tx2 = tm.register_snapshot(1000);
+
+        assert_ne!(tx1, tx2); // Different transaction IDs
+        assert_eq!(tm.active_transaction_count(), 2);
+
+        // Unregister one transaction
+        tm.unregister_snapshot(1000);
+        assert_eq!(tm.active_transaction_count(), 1);
+
+        // Unregister the second transaction
+        tm.unregister_snapshot(1000);
+        assert_eq!(tm.active_transaction_count(), 0);
+    }
+
+    #[test]
+    fn test_multiple_transactions_different_snapshots() {
+        let mut tm = TransactionManager::new();
+
+        // Register transactions for different offsets
+        let _tx1 = tm.register_snapshot(1000);
+        let _tx2 = tm.register_snapshot(2000);
+        let _tx3 = tm.register_snapshot(3000);
+
+        assert_eq!(tm.active_transaction_count(), 3);
+
+        let active_offsets = tm.get_active_offsets();
+        assert_eq!(active_offsets.len(), 3);
+        assert!(active_offsets.contains(&1000));
+        assert!(active_offsets.contains(&2000));
+        assert!(active_offsets.contains(&3000));
+
+        // Unregister middle transaction
+        tm.unregister_snapshot(2000);
+        assert_eq!(tm.active_transaction_count(), 2);
+    }
+
+    #[test]
+    fn test_unregister_nonexistent_snapshot() {
+        let mut tm = TransactionManager::new();
+
+        // Unregistering a non-existent snapshot should not panic
+        tm.unregister_snapshot(9999);
+
+        // Should still work normally
+        let _tx = tm.register_snapshot(1000);
+        assert_eq!(tm.active_transaction_count(), 1);
+    }
+}


### PR DESCRIPTION
This PR implements read-only transactions with snapshot isolation, providing consistent views of the database state. 

- ReadTransaction: Read-only transaction API with automatic snapshot registration/cleanup
- TransactionManager: Reference counting system to track active snapshots and prevent premature pruning (in a future)

--- 

Please check the `examples/transaction.rs` example to view the workflow.

